### PR TITLE
Add Schema member to AbstractStatement struct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ cmd/spirit/spirit
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+.goosehints
+.goose

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -84,11 +84,11 @@ func (m *Migration) normalizeOptions() (stmt *statement.AbstractStatement, err e
 		// This also returns the StmtNode.
 		stmt, err = statement.New(m.Statement)
 		if err != nil {
-			if err == statement.ErrSchemaNameIncluded {
-				return nil, err
-			}
 			// Omit the parser error messages, just show the statement.
 			return nil, errors.New("could not parse SQL statement: " + m.Statement)
+		}
+		if stmt.Schema != "" && stmt.Schema != m.Database {
+			return nil, errors.New("schema name in statement (`schema`.`table`) does not match --database")
 		}
 	} else {
 		if m.Table == "" {

--- a/pkg/migration/migration_test.go
+++ b/pkg/migration/migration_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	_ "github.com/pingcap/tidb/pkg/parser/test_driver"
 
 	"github.com/cashapp/spirit/pkg/testutils"
@@ -443,6 +445,7 @@ func TestCreateIndexIsRewritten(t *testing.T) {
 	testutils.RunSQL(t, tbl)
 	cfg, err := mysql.ParseDSN(testutils.DSN())
 	assert.NoError(t, err)
+	require.NotEqual(t, "", cfg.DBName)
 	migration := &Migration{
 		Host:      cfg.Addr,
 		Username:  cfg.User,
@@ -450,7 +453,7 @@ func TestCreateIndexIsRewritten(t *testing.T) {
 		Database:  cfg.DBName,
 		Threads:   1,
 		Checksum:  true,
-		Statement: "CREATE INDEX idx ON t1createindex (b)",
+		Statement: "CREATE INDEX idx ON " + cfg.DBName + ".t1createindex (b)",
 	}
 	err = migration.Run()
 	assert.NoError(t, err)
@@ -475,6 +478,5 @@ func TestSchemaNameIncluded(t *testing.T) {
 		Statement: "ALTER TABLE test.t1schemaname ADD COLUMN c int",
 	}
 	err = migration.Run()
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "schema name included in the table name is not supported")
+	assert.NoError(t, err)
 }

--- a/pkg/statement/statement.go
+++ b/pkg/statement/statement.go
@@ -13,8 +13,8 @@ import (
 )
 
 type AbstractStatement struct {
-	Schema    string
-	Table     string
+	Schema    string // this will be empty unless the table name is fully qualified (ALTER TABLE test.t1 ...)
+	Table     string // for statements that affect multiple tables (DROP TABLE t1, t2), only the first is set here!
 	Alter     string // may be empty.
 	Statement string
 	StmtNode  *ast.StmtNode
@@ -243,6 +243,8 @@ func convertCreateIndexToAlterTable(stmt ast.StmtNode) (*AbstractStatement, erro
 	alterStmt := fmt.Sprintf("ADD %s %s (%s)", keyType, ciStmt.IndexName, strings.Join(columns, ", "))
 	// We hint in the statement that it's been rewritten
 	// and in the stmtNode we reparse from the alterStmt.
+	// TODO: include schema name if it's explicitly given in the CREATE INDEX statement?
+	// TODO: identifiers should be quoted/escaped in case a maniac includes a backtick in a table name.
 	statement := fmt.Sprintf("ALTER TABLE `%s` %s", ciStmt.Table.Name, alterStmt)
 	p := parser.New()
 	stmtNodes, _, err := p.Parse(statement, "", "")


### PR DESCRIPTION
This PR addresses a limitation in https://github.com/cashapp/spirit/pull/375, that statements with fully-qualified table names (`CREATE TABLE test.t1`) were not supported.